### PR TITLE
Refactor Exposure

### DIFF
--- a/docs/sphinx/api.rst
+++ b/docs/sphinx/api.rst
@@ -48,6 +48,13 @@ Devices
    :members: Telescope, TelescopeSet, KMirror, Focuser, FibSel
    :show-inheritance:
 
+Exposure
+--------
+
+.. automodule:: gort.exposure
+   :members: Exposure
+   :show-inheritance:
+
 Observer
 --------
 
@@ -69,7 +76,7 @@ Recipes
    :members:
    :show-inheritance:
 
-.. automodule:: gort.recipes.calibrations
+.. automodule:: gort.recipes.calibration
    :members:
    :show-inheritance:
 

--- a/src/gort/exposure.py
+++ b/src/gort/exposure.py
@@ -187,10 +187,10 @@ class Exposure(asyncio.Future["Exposure"]):
         monitor_task: asyncio.Task | None = None
 
         try:
-            self.start_time = Time.now()
-
             if show_progress:
                 await self.start_timer(exposure_time or 0.0)
+
+            self.start_time = Time.now()
 
             await self.specs._send_command_all(
                 "expose",

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -56,11 +56,18 @@ class GortObserver:
         self.guide_task: asyncio.Future | None = None
         self.guider_monitor = GuiderMonitor(self)
 
-        self.has_standards: bool = True
         self.standards = Standards(self, tile, self.mask_positions)
+
+        self.__current_exposure: Exposure | None = None
 
     def __repr__(self):
         return f"<GortObserver (tile_id={self.tile.tile_id})>"
+
+    @property
+    def has_standards(self):
+        """Returns `True` if standards will be observed."""
+
+        return len(self.standards.standards) > 0
 
     async def slew(self):
         """Slew to the telescope fields."""
@@ -171,7 +178,6 @@ class GortObserver:
 
         if "spec" not in guide_on_telescopes:
             self.write_to_log("No standards defined. Blocking fibre mask.", "warning")
-            self.has_standards = False
             await self.gort.telescopes.spec.fibsel.move_relative(500)
 
         if n_skies == 0:
@@ -243,6 +249,11 @@ class GortObserver:
         object
             The object name to be added to the header.
 
+        Returns
+        -------
+        exposures
+            Either a single `.Exposure` or a list of exposures if ``count>1``.
+
         """
 
         tile_id = self.tile.tile_id
@@ -252,7 +263,6 @@ class GortObserver:
             object = self.tile.object
 
         exposures: list[Exposure] = []
-        standard_task: asyncio.Task | None = None
 
         for nexp in range(1, count + 1):
             self.write_to_log(
@@ -266,11 +276,12 @@ class GortObserver:
 
             # Move fibre selector to the first position. Should be there unless
             # count > 1 in which case we need to move it back.
-            if self.has_standards:
-                await self.standards.start_iterating(exposure_time)
+            await self.standards.start_iterating(exposure_time)
 
             exposure = Exposure(self.gort, flavour="object", object=object)
-            exposure.hooks["pre-readout"].append(self._update_header)
+            self.__current_exposure = exposure
+
+            exposure.hooks["pre-readout"].append(self._pre_readout)
 
             await exposure.expose(
                 exposure_time=exposure_time,
@@ -279,7 +290,6 @@ class GortObserver:
 
             exposures.append(exposure)
 
-            await cancel_task(standard_task)
             await exposure.register_observation(tile_id=tile_id, dither_pos=dither_pos)
 
         if len(exposures) == 1:
@@ -291,6 +301,9 @@ class GortObserver:
         """Finishes the observation, stops the guiders, etc."""
 
         self.write_to_log("Finishing observation.", "info")
+
+        # Should have been cancelled in _update_header(), but just in case.
+        await self.standards.cancel()
 
         if self.guide_task is not None and not self.guide_task.done():
             await self.gort.guiders.stop()
@@ -335,7 +348,7 @@ class GortObserver:
 
         return sorted(positions, key=lambda p: mask_config[p])
 
-    async def _update_header(self, header: dict[str, Any]):
+    async def _pre_readout(self, header: dict[str, Any]):
         """Updates the exposure header with pointing and guiding information."""
 
         tile_id = self.tile.tile_id
@@ -373,6 +386,14 @@ class GortObserver:
         # This also finishes updating the standards table.
         if self.has_standards:
             await self.standards.cancel()
+
+            # There is some overhead between when we set t0 for the first standard
+            # and when the exposure actually begins. This leads to the first standard
+            # having longer exposure time than open shutter.
+            if self.has_standards and self.__current_exposure is not None:
+                start_time = self.__current_exposure.start_time.unix
+                self.standards.standards.loc[1, "t0"] = start_time
+
             header.update(self.standards.to_header())
 
 
@@ -536,6 +557,9 @@ class Standards:
 
         """
 
+        if len(self.standards) == 0:
+            return
+
         await self.gort.telescopes.spec.fibsel.move_to_position(self.mask_positions[0])
         await self.cancel()
 
@@ -553,9 +577,13 @@ class Standards:
 
         await cancel_task(self.iterate_task)
 
+        if len(self.standards) == 0:
+            return
+
         if self.standards.loc[self.current_standard].acquired == 1:
-            self.standards.loc[self.current_standard, "observed"] = 1
-            self.standards.loc[self.current_standard, "t1"] = time()
+            if self.standards.loc[self.current_standard, "observed"] != 1:
+                self.standards.loc[self.current_standard, "observed"] = 1
+                self.standards.loc[self.current_standard, "t1"] = time()
 
     async def _iterate(self, exposure_time: float):
         """Iterate task."""

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -270,6 +270,8 @@ class GortObserver:
                 await self.standards.start_iterating(exposure_time)
 
             exposure = Exposure(self.gort, flavour="object", object=object)
+            exposure.hooks["pre-readout"].append(self._update_header)
+
             await exposure.expose(
                 exposure_time=exposure_time,
                 show_progress=show_progress,


### PR DESCRIPTION
Move some of the code from `SpectrographSet.expose()` to `Exposure` and `Exposure.expose()` so that `Exposure` can be more readily used.

`GortObserver.expose()` now directly calls `Exposure.expose()` for finer grain control.

Added a system of hooks for the exposure process. For now only a `pre-readout` hook that is called with the header before the exposure is read.