### PR TITLE
Reduce overheads and support dithering

### DIFF
--- a/src/gort/devices/spec.py
+++ b/src/gort/devices/spec.py
@@ -394,7 +394,7 @@ class SpectrographSet(GortDeviceSet[Spectrograph]):
 
         exposures: list[Exposure] = []
 
-        for _ in range(int(count)):
+        for nexp in range(int(count)):
             exposure = Exposure(self.gort, flavour=flavour, object=object)
 
             log_msg = f"Taking spectrograph exposure {exposure.exp_no} "
@@ -404,13 +404,18 @@ class SpectrographSet(GortDeviceSet[Spectrograph]):
                 log_msg += f"({flavour}, {exposure_time:.1f} s)."
             self.write_to_log(log_msg, "info")
 
+            async_readout_this_exp = async_readout if nexp == int(count) - 1 else False
+
             await exposure.expose(
                 exposure_time=exposure_time,
                 header=header,
-                async_readout=async_readout,
+                async_readout=async_readout_this_exp,
                 show_progress=show_progress,
             )
             exposures.append(exposure)
+
+        if async_readout:
+            self.write_to_log("Returning with async readout ongoing.")
 
         if len(exposures) == 1:
             return exposures[0]

--- a/src/gort/etc/lvmgort.yml
+++ b/src/gort/etc/lvmgort.yml
@@ -92,6 +92,16 @@ guiders:
   devices:
     sci:
       actor: lvm.sci.guider
+      dither_offsets:
+        0: [0.00, 0.00]
+        1: [-10.68, 18.50]
+        2: [10.68, 18.50]
+        3: [0.00, -12.33]
+        4: [10.68, -6.17]
+        5: [-10.68, -6.17]
+        6: [10.68, 6.17]
+        7: [-10.68, 6.17]
+        8: [0.00, 12.33]
     spec:
       actor: lvm.spec.guider
       named_pixels:

--- a/src/gort/etc/lvmgort.yml
+++ b/src/gort/etc/lvmgort.yml
@@ -324,7 +324,10 @@ site:
   height: 2282.0
 
 database:
-  host: lvm-webapp.lco.cl
-  port: 5432
-  user: sdss
-  database: lvmdb
+  connection:
+    host: lvm-webapp.lco.cl
+    port: 5432
+    user: sdss
+    database: lvmdb
+  tables:
+    overhead: lvmopsdb.overhead

--- a/src/gort/exposure.py
+++ b/src/gort/exposure.py
@@ -153,6 +153,12 @@ class Exposure(asyncio.Future["Exposure"]):
 
         """
 
+        log = self.specs.write_to_log
+
+        if self.specs.last_exposure is not None and not self.specs.last_exposure.done():
+            log("Waiting for previous exposure to read out.", "warning")
+            await self.specs.last_exposure
+
         # Check that all specs are idle and not errored.
         status = await self.specs.status(simple=True)
         for spec_status in status.values():
@@ -234,10 +240,10 @@ class Exposure(asyncio.Future["Exposure"]):
             if not async_readout:
                 await readout_task
                 await monitor_task
-                self.specs.write_to_log(f"Exposure {self.exp_no} completed.")
+                log(f"Exposure {self.exp_no} completed.")
             else:
                 await self.stop_timer()
-                self.specs.write_to_log("Returning with async readout ongoing.")
+                log("Returning with async readout ongoing.")
 
         except Exception as err:
             # Cancel the monitor task

--- a/src/gort/exposure.py
+++ b/src/gort/exposure.py
@@ -243,7 +243,6 @@ class Exposure(asyncio.Future["Exposure"]):
                 log(f"Exposure {self.exp_no} completed.")
             else:
                 await self.stop_timer()
-                log("Returning with async readout ongoing.")
 
         except Exception as err:
             # Cancel the monitor task

--- a/src/gort/gort.py
+++ b/src/gort/gort.py
@@ -656,6 +656,8 @@ class Gort(GortClient):
         use_scheduler: bool = False,
         exposure_time: float = 900.0,
         n_exposures: int = 1,
+        async_readout: bool = True,
+        keep_guiding: bool = False,
         guide_tolerance: float = 1.0,
         acquisition_timeout: float = 180.0,
         show_progress: bool | None = None,
@@ -681,6 +683,15 @@ class Gort(GortClient):
             The length of the exposure in seconds.
         n_exposures
             Number of exposures to take while guiding.
+        async_readout
+            Whether to wait for the readout to complete or return as soon
+            as the readout begins. If :obj:`False`, the exposure is registered
+            but the observation is not finished. This should be :obj:`True`
+            during normal science operations to allow the following acquisition
+            to occur during readout.
+        keep_guiding
+            If :obj:`True`, keeps the guider running after the last exposure.
+            This should be :obj:`False` during normal science operations.
         guide_tolerance
             The guide tolerance in arcsec. A telescope will not be considered
             to be guiding if its separation to the commanded field is larger
@@ -735,6 +746,8 @@ class Gort(GortClient):
                 exposure_time=exposure_time,
                 show_progress=show_progress,
                 count=n_exposures,
+                async_readout=async_readout,
+                keep_guiding=keep_guiding,
             )
 
         finally:

--- a/src/gort/gort.py
+++ b/src/gort/gort.py
@@ -653,7 +653,7 @@ class Gort(GortClient):
         ra: float | None = None,
         dec: float | None = None,
         pa: float = 0.0,
-        use_scheduler: bool = False,
+        use_scheduler: bool = True,
         exposure_time: float = 900.0,
         n_exposures: int = 1,
         async_readout: bool = True,

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from contextlib import contextmanager
 from time import time
 
 from typing import TYPE_CHECKING, Any
@@ -22,7 +23,12 @@ from astropy.time import Time
 from gort.exceptions import GortObserverError
 from gort.exposure import Exposure
 from gort.tile import Coordinates
-from gort.tools import build_guider_reply_list, cancel_task, register_observation
+from gort.tools import (
+    build_guider_reply_list,
+    cancel_task,
+    insert_to_database,
+    register_observation,
+)
 from gort.transforms import fibre_slew_coordinates
 
 
@@ -62,6 +68,8 @@ class GortObserver:
         self.__current_exposure: Exposure | None = None
         self._n_exposures: int = 0
 
+        self.overheads: dict[str, tuple[float, float]] = {}
+
     def __repr__(self):
         return f"<GortObserver (tile_id={self.tile.tile_id})>"
 
@@ -78,8 +86,9 @@ class GortObserver:
 
         cotasks = []
 
-        # Stops guiders.
-        await self.gort.guiders.stop()
+        with self.register_overhead("slew:stop-guiders"):
+            # Stops guiders.
+            await self.gort.guiders.stop()
 
         # Slew telescopes.
         self.write_to_log(f"Slewing to tile_id={tile.tile_id}.", level="info")
@@ -130,7 +139,8 @@ class GortObserver:
         cotasks.append(fibsel.move_to_position(self.mask_positions[0]))
 
         # Execute.
-        await asyncio.gather(*cotasks)
+        with self.register_overhead("slew:slew"):
+            await asyncio.gather(*cotasks)
 
     async def acquire(self, guide_tolerance: float = 1, timeout: float = 180):
         """Acquires the field in all the telescopes. Blocks until then.
@@ -154,10 +164,11 @@ class GortObserver:
 
         """
 
-        # Make sure we are not guiding or that the previous is on.
-        if self.guide_task is not None and not self.guide_task.done():
-            await self.gort.guiders.stop()
-            await cancel_task(self.guide_task)
+        with self.register_overhead("acquisition:stop-guiders"):
+            # Make sure we are not guiding or that the previous is on.
+            if self.guide_task is not None and not self.guide_task.done():
+                await self.gort.guiders.stop()
+                await cancel_task(self.guide_task)
 
         # Determine telescopes on which to guide.
         guide_coros = []
@@ -192,27 +203,30 @@ class GortObserver:
                 )
             )
 
-        if "spec" not in guide_on_telescopes:
-            self.write_to_log("No standards defined. Blocking fibre mask.", "warning")
-            await self.gort.telescopes.spec.fibsel.move_relative(500)
+            if "spec" not in guide_on_telescopes:
+                with self.register_overhead("acquisition:move-fibsel-500"):
+                    self.write_to_log("Not using spec: blocking fibre mask.", "warning")
+                    await self.gort.telescopes.spec.fibsel.move_relative(500)
 
         if n_skies == 0:
             self.write_to_log("No sky positions defined.", "warning")
 
-        # Start guide loop.
-        await self.guider_monitor.restart()
-        self.guide_task = asyncio.gather(*guide_coros)
+        with self.register_overhead("acquisition:start-guide-loop"):
+            # Start guide loop.
+            await self.guider_monitor.restart()
+            self.guide_task = asyncio.gather(*guide_coros)
 
-        await asyncio.sleep(5)
+        with self.register_overhead("acquisition:acquire"):
+            await asyncio.sleep(2)
 
-        # Wait until convergence.
-        self.write_to_log("Waiting for guiders to converge.")
-        guide_status = await asyncio.gather(
-            *[
-                self.gort.guiders[tel].wait_until_guiding(timeout=timeout)
-                for tel in guide_on_telescopes
-            ]
-        )
+            # Wait until convergence.
+            self.write_to_log("Waiting for guiders to converge.")
+            guide_status = await asyncio.gather(
+                *[
+                    self.gort.guiders[tel].wait_until_guiding(timeout=timeout)
+                    for tel in guide_on_telescopes
+                ]
+            )
 
         has_timedout = any([gs[3] for gs in guide_status])
         if has_timedout:
@@ -297,38 +311,42 @@ class GortObserver:
                 "info",
             )
 
-            # Refresh guider data for this exposure.
-            if self._n_exposures > 0:
-                await self.guider_monitor.restart()
+            with self.register_overhead("expose:pre-exposure"):
+                # Refresh guider data for this exposure.
+                if self._n_exposures > 0:
+                    await self.guider_monitor.restart()
 
-            # Move fibre selector to the first position. Should be there unless
-            # count > 1 in which case we need to move it back.
-            await self.standards.start_iterating(exposure_time)
+                # Move fibre selector to the first position. Should be there unless
+                # count > 1 in which case we need to move it back.
+                await self.standards.start_iterating(exposure_time)
 
-            exposure = Exposure(self.gort, flavour="object", object=object)
-            self.__current_exposure = exposure
+                exposure = Exposure(self.gort, flavour="object", object=object)
+                self.__current_exposure = exposure
 
             exposure.hooks["pre-readout"].append(self._pre_readout)
             exposure.hooks["post-readout"].append(self._post_readout)
 
-            await exposure.expose(
-                exposure_time=exposure_time,
-                show_progress=show_progress,
-                async_readout=True,
-            )
+            with self.register_overhead("expose:integration"):
+                await exposure.expose(
+                    exposure_time=exposure_time,
+                    show_progress=show_progress,
+                    async_readout=True,
+                )
 
             # TODO: this is a bit dangerous because we are registering the
             # exposure before  it's actually written to disk. Maybe we should
             # wait until _post_readout() to register, but then the scheduler
             # needs to be changed to not return the same tile twice.
-            await self.register_exposure(
-                exposure,
-                tile_id=tile_id,
-                dither_pos=dither_pos,
-            )
+            with self.register_overhead("exposure:register-exposure"):
+                await self.register_exposure(
+                    exposure,
+                    tile_id=tile_id,
+                    dither_pos=dither_pos,
+                )
 
             if nexp == count and not keep_guiding:
-                await self.gort.guiders.stop()
+                with self.register_overhead("expose:stop-guiders"):
+                    await self.gort.guiders.stop()
 
             if nexp == count and async_readout:
                 return exposure
@@ -348,12 +366,31 @@ class GortObserver:
 
         self.write_to_log("Finishing observation.", "info")
 
-        # Should have been cancelled in _update_header(), but just in case.
-        await self.standards.cancel()
+        with self.register_overhead("finish-observation"):
+            # Should have been cancelled in _update_header(), but just in case.
+            await self.standards.cancel()
 
-        if self.guide_task is not None and not self.guide_task.done():
-            await self.gort.guiders.stop()
-            await self.guide_task
+            if self.guide_task is not None and not self.guide_task.done():
+                await self.gort.guiders.stop()
+                await self.guide_task
+
+        # Write overheads to database.
+        payload = [
+            {
+                "observer_id": id(self),
+                "stage": name,
+                "start_time": value[0],
+                "end_time": value[0] + value[1],
+                "duration": value[1],
+            }
+            for name, value in self.overheads.items()
+        ]
+
+        try:
+            table_name = self.gort.config["database"]["tables"]["overhead"]
+            insert_to_database(table_name, payload)
+        except Exception as err:
+            self.write_to_log(f"Failed saving overheads to database: {err}", "error")
 
     async def register_exposure(
         self,
@@ -421,6 +458,16 @@ class GortObserver:
         assert isinstance(level, int)
 
         self.gort.log.log(level, message)
+
+    @contextmanager
+    def register_overhead(self, name: str):
+        """Measures and registers and overhead."""
+
+        t0 = time()
+
+        yield
+
+        self.overheads[name] = (t0, time() - t0)
 
     def _get_mask_positions(self, pattern: str):
         """Returns mask positions sorted by motor steps."""
@@ -753,6 +800,7 @@ class Standards:
                 # Increase current index and get coordinates.
                 current_std_idx += 1
                 self.current_standard += 1
+                overhead_root = f"standards:standard-{self.current_standard}"
 
                 # New coordinates to observe.
                 new_coords = spec_coords[current_std_idx]
@@ -781,13 +829,14 @@ class Standards:
                 )
 
                 # Finish guiding on spec telescope.
-                self.observer.write_to_log("Stopping guiding on spec and reslewing.")
+                self.observer.write_to_log("Re-slewing 'spec' telescope.")
 
-                cotasks = [
-                    self.gort.guiders["spec"].stop(),
-                    spec_tel.goto_coordinates(ra=slew_ra, dec=slew_dec),
-                ]
-                await asyncio.gather(*cotasks)
+                with self.observer.register_overhead(f"{overhead_root}-slew"):
+                    cotasks = [
+                        self.gort.guiders["spec"].stop(),
+                        spec_tel.goto_coordinates(ra=slew_ra, dec=slew_dec),
+                    ]
+                    await asyncio.gather(*cotasks)
 
                 # Start to guide. Note that here we use the original coordinates
                 # of the star along with the pixel on the master frame on which to
@@ -802,18 +851,22 @@ class Standards:
                     )
                 )
 
-                result = await self.gort.guiders.spec.wait_until_guiding(timeout=60)
-                if result[0] is False:
+                with self.observer.register_overhead(f"{overhead_root}-acquire"):
+                    result = await self.gort.guiders.spec.wait_until_guiding(timeout=60)
+                    if result[0] is False:
+                        self.observer.write_to_log(
+                            f"Timed out acquiring standard {self.current_standard}.",
+                            "warning",
+                        )
+                        continue
+
                     self.observer.write_to_log(
-                        "Failed to acquire standard position. Skipping.",
-                        "warning",
+                        f"Standard #{self.current_standard} on "
+                        f"{new_mask_position!r} has been acquired."
                     )
-                    continue
 
-                self.observer.write_to_log(f"Standard {new_mask_position} acquired.")
-
-                # Move mask to uncover fibre.
-                await spec_tel.fibsel.move_to_position(new_mask_position)
+                    # Move mask to uncover fibre.
+                    await spec_tel.fibsel.move_to_position(new_mask_position)
 
                 n_observed += 1
                 t0_last_std = time()

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -374,10 +374,15 @@ class GortObserver:
                 await self.gort.guiders.stop()
                 await self.guide_task
 
+        tile_id = self.tile.tile_id
+        if tile_id is None or tile_id <= 0:
+            tile_id = None
+
         # Write overheads to database.
         payload = [
             {
                 "observer_id": id(self),
+                "tile_id": tile_id,
                 "stage": name,
                 "start_time": value[0],
                 "end_time": value[0] + value[1],

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -311,7 +311,7 @@ class GortObserver:
                 "info",
             )
 
-            with self.register_overhead("expose:pre-exposure"):
+            with self.register_overhead(f"expose:pre-exposure-{nexp}"):
                 # Refresh guider data for this exposure.
                 if self._n_exposures > 0:
                     await self.guider_monitor.restart()
@@ -326,7 +326,7 @@ class GortObserver:
             exposure.hooks["pre-readout"].append(self._pre_readout)
             exposure.hooks["post-readout"].append(self._post_readout)
 
-            with self.register_overhead("expose:integration"):
+            with self.register_overhead(f"expose:integration-{nexp}"):
                 await exposure.expose(
                     exposure_time=exposure_time,
                     show_progress=show_progress,
@@ -337,7 +337,7 @@ class GortObserver:
             # exposure before  it's actually written to disk. Maybe we should
             # wait until _post_readout() to register, but then the scheduler
             # needs to be changed to not return the same tile twice.
-            with self.register_overhead("exposure:register-exposure"):
+            with self.register_overhead(f"exposure:register-exposure-{nexp}"):
                 await self.register_exposure(
                     exposure,
                     tile_id=tile_id,
@@ -345,7 +345,7 @@ class GortObserver:
                 )
 
             if nexp == count and not keep_guiding:
-                with self.register_overhead("expose:stop-guiders"):
+                with self.register_overhead(f"expose:stop-guiders-{nexp}"):
                     await self.gort.guiders.stop()
 
             if nexp == count and async_readout:

--- a/src/gort/observer.py
+++ b/src/gort/observer.py
@@ -301,6 +301,7 @@ class GortObserver:
             self.__current_exposure = exposure
 
             exposure.hooks["pre-readout"].append(self._pre_readout)
+            exposure.hooks["post-readout"].append(self._post_readout)
 
             await exposure.expose(
                 exposure_time=exposure_time,
@@ -461,6 +462,11 @@ class GortObserver:
                 self.standards.standards.loc[1, "t0"] = start_time
 
             header.update(self.standards.to_header())
+
+    async def _post_readout(self, exposure: Exposure):
+        """Post exposure tasks."""
+
+        return
 
 
 class GuiderMonitor:

--- a/src/gort/recipes/operations.py
+++ b/src/gort/recipes/operations.py
@@ -137,7 +137,7 @@ class ShutdownRecipe(BaseRecipe):
         await self.gort.nps.calib.all_off()
 
         self.gort.log.info("Making sure guiders are idle.")
-        await self.gort.guiders.stop(now=True)
+        await self.gort.guiders.stop()
 
         await self.gort.enclosure.close()
 
@@ -165,7 +165,7 @@ class CleanupRecipe(BaseRecipe):
         """
 
         self.gort.log.info("Stopping the guiders.")
-        await self.gort.guiders.stop(now=False)
+        await self.gort.guiders.stop()
 
         if not (await self.gort.specs.are_idle()):
             cotasks = []

--- a/src/gort/tile.py
+++ b/src/gort/tile.py
@@ -147,7 +147,7 @@ class QuerableCoordinates(Coordinates):
     def from_science_coordinates(
         cls,
         sci_coords: ScienceCoordinates,
-        exclude_coordinates: list[CoordTuple] = [],
+        exclude_coordinates: Sequence[CoordTuple] = [],
         exclude_invisible: bool = True,
     ):
         """Retrieves a valid and observable position from the database.
@@ -201,7 +201,7 @@ class QuerableCoordinates(Coordinates):
 
         return cls(skycoord_min.ra.deg, skycoord_min.dec.deg)
 
-    def verify_and_replace(self, exclude_coordinates: list[CoordTuple] = []):
+    def verify_and_replace(self, exclude_coordinates: Sequence[CoordTuple] = []):
         """Verifies that the coordinates are visible and if not, replaces them.
 
         Parameters
@@ -273,7 +273,7 @@ class StandardCoordinates(QuerableCoordinates):
         super().__init__(*args, **kwargs)
 
 
-class Tile(dict[str, Coordinates | list[Coordinates] | None]):
+class Tile(dict[str, Coordinates | Sequence[Coordinates] | None]):
     """A representation of a science pointing with associated calibrators.
 
     This class is most usually initialised from a classmethod like
@@ -288,7 +288,7 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
     spec_coords
         A list of coordinates to observe with the spectrophotometric telescope.
     dither_position
-        The dither position to obseve (not yet functional).
+        The dither position(s) to obseve.
     object
         The name of the object.
     allow_replacement
@@ -301,7 +301,7 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
         self,
         sci_coords: ScienceCoordinates,
         sky_coords: dict[str, SkyCoordinates] | dict[str, CoordTuple] | None = None,
-        spec_coords: list[StandardCoordinates | CoordTuple] | None = None,
+        spec_coords: Sequence[StandardCoordinates | CoordTuple] | None = None,
         dither_positions: int | Sequence[int] = 0,
         object: str | None = None,
         allow_replacement: bool = True,
@@ -382,13 +382,13 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
     def spec_coords(self):
         """Returns the Spec coordinates."""
 
-        return cast(list[StandardCoordinates], self["spec"])
+        return cast(Sequence[StandardCoordinates], self["spec"])
 
     @spec_coords.setter
-    def spec_coords(self, new_coords: list[StandardCoordinates]):
+    def spec_coords(self, new_coords: Sequence[StandardCoordinates]):
         """Sets the SkyW coordinates."""
 
-        parsed_coords: list[Coordinates] = []
+        parsed_coords: Sequence[Coordinates] = []
         for coords in new_coords:
             if isinstance(coords, (list, tuple)):
                 parsed_coords.append(StandardCoordinates(*coords))
@@ -404,7 +404,7 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
         dec: float,
         pa: float = 0.0,
         sky_coords: dict[str, SkyCoordinates] | dict[str, CoordTuple] | None = None,
-        spec_coords: list[StandardCoordinates | CoordTuple] | None = None,
+        spec_coords: Sequence[StandardCoordinates | CoordTuple] | None = None,
         **kwargs,
     ):
         """Creates an instance from coordinates, allowing autocompletion.
@@ -590,7 +590,7 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
             sky_coords = {}
 
         valid_sky_coords: dict[str, SkyCoordinates] = {}
-        assigned_coordinates: list[CoordTuple] = []
+        assigned_coordinates: Sequence[CoordTuple] = []
 
         for telescope in ["skye", "skyw"]:
             tel_coords = sky_coords.get(telescope, None)
@@ -655,9 +655,9 @@ class Tile(dict[str, Coordinates | list[Coordinates] | None]):
 
     def set_spec_coords(
         self,
-        spec_coords: list[StandardCoordinates | CoordTuple] | None = None,
+        spec_coords: Sequence[StandardCoordinates | CoordTuple] | None = None,
         reject_invisible: bool = True,
-    ) -> list[StandardCoordinates]:
+    ) -> Sequence[StandardCoordinates]:
         """Sets the spec telescope coordinates.
 
         Parameters


### PR DESCRIPTION
This PR focuses on improving overheads during normal tiled observations. It also enables dithering. It is meant to run alongside `lvmguider 0.4.0`.

- Remove calls to `lvmguider stop --now`. The new `stop` command always cancels the guider task.
- Added `pre-readout` hook for `Exposure`.
- Allow `GortObserver` to read out an exposure asynchronously.
- `Gort.observe_tile()` will by default read the last exposure asynchronously to allow for the next slew and acquisition to happen during readout.
- Added a context manager `GortObserver.register_overhead()` that measured the elapsed time in different parts of the slew and acquisition process and records the values to the database.
- The dither positions associated with a `Tile` are now a list of positions that the scheduler wants us to observe. `Gort.observe_tile()` will try to observe all dither positions without stopping the guider.
- Added `Gort.observe()` with a simple loop for observing tiles.