### PR TITLE
Refactor core classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* [#40](https://github.com/sdss/lvmgort/pull/40) Slight internal restructuring of the core classes `Gort`, `GortClient`, device and remote actor classes. The main goal was to avoid any other part of the library knowing about `GortClient`, which does not include anything not related to its AMQP client function anymore.
+
+
 ## 1.2.1 - November 20, 2024
 
 ### ✨ Improved

--- a/src/gort/__init__.py
+++ b/src/gort/__init__.py
@@ -23,9 +23,9 @@ conf.iers_degraded_accuracy = "ignore"
 iers_a = iers.IERS_A.open(iers.IERS_A_FILE)
 iers.earth_orientation_table.set(iers_a)
 
-from .core import *
 from .devices import *
 from .exposure import *
 from .gort import *
 from .observer import *
+from .remote import *
 from .tile import *

--- a/src/gort/devices/ag.py
+++ b/src/gort/devices/ag.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 
-from gort.gort import GortDevice, GortDeviceSet
+from gort.devices.core import GortDevice, GortDeviceSet
 
 
 __all__ = ["AG", "AGSet"]

--- a/src/gort/devices/core.py
+++ b/src/gort/devices/core.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2024-11-27
+# @Filename: core.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Generic,
+    Sequence,
+    Type,
+    TypeVar,
+)
+
+from packaging.version import Version
+
+from clu.client import AMQPReply
+
+from gort.exceptions import GortError
+from gort.tools import kubernetes_list_deployments, kubernetes_restart_deployment
+
+
+if TYPE_CHECKING:
+    from gort.gort import Gort
+
+
+GortDeviceType = TypeVar("GortDeviceType", bound="GortDevice")
+
+
+class GortDeviceSet(dict[str, GortDeviceType], Generic[GortDeviceType]):
+    """A set to gort-managed devices.
+
+    Devices can be accessed as items of the :obj:`.GortDeviceSet` dictionary
+    or using dot notation, as attributes.
+
+    Parameters
+    ----------
+    gort
+        The :obj:`.Gort` instance.
+    data
+        A mapping of device to device info. Each device must at least include
+        an ``actor`` key with the actor to use to communicated with the device.
+        Any other information is passed to the :obj:`.GortDevice` on instantiation.
+    kwargs
+        Other keyword arguments to pass wo the device class.
+
+    """
+
+    __DEVICE_CLASS__: ClassVar[Type["GortDevice"]]
+    __DEPLOYMENTS__: ClassVar[list[str]] = []
+
+    def __init__(self, gort: Gort, data: dict[str, dict], **kwargs):
+        self.gort = gort
+
+        _dict_data = {}
+        for device_name in data:
+            device_data = data[device_name].copy()
+            actor_name = device_data.pop("actor")
+            _dict_data[device_name] = self.__DEVICE_CLASS__(
+                gort,
+                device_name,
+                actor_name,
+                **device_data,
+                **kwargs,
+            )
+
+        dict.__init__(self, _dict_data)
+
+    async def init(self):
+        """Runs asynchronous tasks that must be executed on init."""
+
+        # Run devices init methods.
+        results = await asyncio.gather(
+            *[dev.init() for dev in self.values()],
+            return_exceptions=True,
+        )
+
+        for idev, result in enumerate(results):
+            if isinstance(result, Exception):
+                self.write_to_log(
+                    f"Failed initialising device {list(self)[idev]} "
+                    f"with error {str(result)}",
+                    "error",
+                )
+
+        return
+
+    def __getattribute__(self, __name: str) -> Any:
+        if __name in self:
+            return self.__getitem__(__name)
+        return super().__getattribute__(__name)
+
+    async def call_device_method(self, method: Callable, *args, **kwargs):
+        """Calls a method in each one of the devices.
+
+        Parameters
+        ----------
+        method
+            The method to call. This must be the abstract class method,
+            not the method from an instantiated object.
+        args,kwargs
+            Arguments to pass to the method.
+
+        """
+
+        if not callable(method):
+            raise GortError("Method is not callable.")
+
+        if hasattr(method, "__self__"):
+            # This is a bound method, so let's get the class method.
+            method = method.__func__
+
+        if not hasattr(self.__DEVICE_CLASS__, method.__name__):
+            raise GortError("Method does not belong to this class devices.")
+
+        devices = self.values()
+
+        return await asyncio.gather(*[method(dev, *args, **kwargs) for dev in devices])
+
+    async def send_command_all(
+        self,
+        command: str,
+        *args,
+        devices: Sequence[str] | None = None,
+        **kwargs,
+    ):
+        """Sends a command to all the devices.
+
+        Parameters
+        ----------
+        command
+            The command to call.
+        args, kwargs
+            Arguments to pass to the :obj:`.RemoteCommand`.
+
+        """
+
+        tasks = []
+        for name, dev in self.items():
+            if devices is not None and name not in devices:
+                continue
+
+            actor_command = dev.actor.commands[command]
+            tasks.append(actor_command(*args, **kwargs))
+
+        return await asyncio.gather(*tasks)
+
+    def write_to_log(
+        self,
+        message: str,
+        level: str = "debug",
+        header: str | None = None,
+    ):
+        """Writes a message to the log with a custom header.
+
+        Parameters
+        ----------
+        message
+            The message to log.
+        level
+            The level to use for logging: ``'debug'``, ``'info'``, ``'warning'``, or
+            ``'error'``.
+        header
+            The header to prepend to the message. By default uses the class name.
+
+        """
+
+        if header is None:
+            header = f"({self.__class__.__name__}) "
+
+        message = f"{header}{message}"
+
+        level = logging.getLevelName(level.upper())
+        assert isinstance(level, int)
+
+        self.gort.log.log(level, message)
+
+    async def restart(self):
+        """Restarts the set deployments and resets all controllers.
+
+        Returns
+        -------
+        result
+            A boolean indicting if the entire restart procedure succeeded.
+
+        """
+
+        failed: bool = False
+
+        self.write_to_log("Restarting Kubernetes deployments.", "info")
+        for deployment in self.__DEPLOYMENTS__:
+            await kubernetes_restart_deployment(deployment)
+
+        self.write_to_log("Waiting 15 seconds for deployments to be ready.", "info")
+        await asyncio.sleep(15)
+
+        # Check that deployments are running.
+        running_deployments = await kubernetes_list_deployments()
+        for deployment in self.__DEPLOYMENTS__:
+            if deployment not in running_deployments:
+                failed = True
+                self.write_to_log(f"Deployment {deployment} did not restart.", "error")
+
+        # Refresh the command models for all the actors.
+        await asyncio.gather(*[actor.refresh() for actor in self.gort.actors.values()])
+
+        # Refresh the device set.
+        await self.init()
+
+        return not failed
+
+
+class GortDevice:
+    """A gort-managed device.
+
+    Parameters
+    ----------
+    gort
+        The :obj:`.Gort` instance.
+    name
+        The name of the device.
+    actor
+        The name of the actor used to interface with this device. The actor is
+        added to the list of :obj:`.RemoteActor` in the :obj:`.Gort`.
+
+
+    """
+
+    def __init__(self, gort: Gort, name: str, actor: str):
+        self.gort = gort
+        self.name = name
+        self.actor = gort.add_actor(actor, device=self)
+
+        # Placeholder version. The real one is retrieved on init.
+        self.version = Version("0.99.0")
+
+    async def init(self):
+        """Runs asynchronous tasks that must be executed on init.
+
+        If the device is part of a :obj:`.DeviceSet`, this method is called
+        by :obj:`.DeviceSet.init`.
+
+        """
+
+        # Get the version of the actor.
+        if "version" in self.actor.commands:
+            try:
+                reply = await self.actor.commands.version()
+                if (version := reply.get("version")) is not None:
+                    self.version = Version(version)
+            except Exception:
+                pass
+
+        return
+
+    def write_to_log(
+        self,
+        message: str,
+        level: str = "debug",
+        header: str | None = None,
+    ):
+        """Writes a message to the log with a custom header.
+
+        Parameters
+        ----------
+        message
+            The message to log.
+        level
+            The level to use for logging: ``'debug'``, ``'info'``, ``'warning'``, or
+            ``'error'``.
+        header
+            The header to prepend to the message. By default uses the device name.
+
+        """
+
+        if header is None:
+            header = f"({self.name}) "
+
+        message = f"{header}{message}"
+
+        level = logging.getLevelName(level.upper())
+        assert isinstance(level, int)
+
+        self.gort.log.log(level, message)
+
+    def log_replies(self, reply: AMQPReply, skip_debug: bool = True):
+        """Outputs command replies."""
+
+        if reply.body:
+            if reply.message_code in ["w"]:
+                level = "warning"
+            elif reply.message_code in ["e", "f", "!"]:
+                level = "error"
+            else:
+                level = "debug"
+                if skip_debug:
+                    return
+
+            self.write_to_log(str(reply.body), level)

--- a/src/gort/devices/guider.py
+++ b/src/gort/devices/guider.py
@@ -18,17 +18,17 @@ import polars
 from packaging.version import Version
 
 from gort import config
+from gort.devices.core import GortDevice, GortDeviceSet
 from gort.enums import GuiderStatus
 from gort.exceptions import ErrorCode, GortError, GortGuiderError
-from gort.gort import GortDevice, GortDeviceSet
 from gort.tools import GuiderMonitor, cancel_task
 
 
 if TYPE_CHECKING:
     from clu import AMQPReply
 
-    from gort.core import ActorReply
-    from gort.gort import GortClient
+    from gort.gort import Gort
+    from gort.remote import ActorReply
 
 
 __all__ = ["Guider", "GuiderSet"]
@@ -37,7 +37,7 @@ __all__ = ["Guider", "GuiderSet"]
 class Guider(GortDevice):
     """Class representing a guider."""
 
-    def __init__(self, gort: GortClient, name: str, actor: str, **kwargs):
+    def __init__(self, gort: Gort, name: str, actor: str, **kwargs):
         super().__init__(gort, name, actor)
 
         self.separation: float | None = None

--- a/src/gort/devices/nps.py
+++ b/src/gort/devices/nps.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from gort.gort import GortDevice, GortDeviceSet
+from gort.devices.core import GortDevice, GortDeviceSet
 
 
 if TYPE_CHECKING:
     from gort import ActorReply
-    from gort.gort import GortClient
+    from gort.gort import Gort
 
 
 __all__ = ["NPS", "NPSSet"]
@@ -24,7 +24,7 @@ __all__ = ["NPS", "NPSSet"]
 class NPS(GortDevice):
     """Class representing a networked power switch."""
 
-    def __init__(self, gort: GortClient, name: str, actor: str, **kwargs):
+    def __init__(self, gort: Gort, name: str, actor: str, **kwargs):
         super().__init__(gort, name, actor)
 
     async def status(self, outlet: int | str | None = None):

--- a/src/gort/devices/spec.py
+++ b/src/gort/devices/spec.py
@@ -12,14 +12,14 @@ import asyncio
 
 from typing import TYPE_CHECKING, Sequence
 
+from gort.devices.core import GortDevice, GortDeviceSet
 from gort.exceptions import ErrorCode, GortError, GortSpecError
 from gort.exposure import Exposure
-from gort.gort import GortDevice, GortDeviceSet
 
 
 if TYPE_CHECKING:
-    from gort.core import ActorReply
-    from gort.gort import GortClient
+    from gort.gort import Gort
+    from gort.remote import ActorReply
 
 
 __all__ = ["Spectrograph", "SpectrographSet", "IEB"]
@@ -28,7 +28,7 @@ __all__ = ["Spectrograph", "SpectrographSet", "IEB"]
 class IEB(GortDevice):
     """A class representing an Instrument Electronics Box."""
 
-    def __init__(self, gort: GortClient, name: str, actor: str):
+    def __init__(self, gort: Gort, name: str, actor: str):
         super().__init__(gort, name, actor)
 
         self.spec_name = self.name.split(".")[1]
@@ -220,7 +220,7 @@ class IEB(GortDevice):
 class Spectrograph(GortDevice):
     """Class representing an LVM spectrograph functionality."""
 
-    def __init__(self, gort: GortClient, name: str, actor: str, **kwargs):
+    def __init__(self, gort: Gort, name: str, actor: str, **kwargs):
         super().__init__(gort, name, actor)
 
         self.nps = self.gort.nps[name]
@@ -346,7 +346,7 @@ class SpectrographSet(GortDeviceSet[Spectrograph]):
     __DEVICE_CLASS__ = Spectrograph
     __DEPLOYMENTS__ = ["lvmscp"]
 
-    def __init__(self, gort: GortClient, data: dict[str, dict], **kwargs):
+    def __init__(self, gort: Gort, data: dict[str, dict], **kwargs):
         super().__init__(gort, data, **kwargs)
 
         self.last_exposure: Exposure | None = None

--- a/src/gort/devices/telemetry.py
+++ b/src/gort/devices/telemetry.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from gort.gort import GortDevice, GortDeviceSet
+from gort.devices.core import GortDevice, GortDeviceSet
 
 
 if TYPE_CHECKING:
     from gort import ActorReply
-    from gort.gort import GortClient
+    from gort.gort import Gort
 
 
 __all__ = ["Telemetry", "TelemetrySet"]
@@ -24,7 +24,7 @@ __all__ = ["Telemetry", "TelemetrySet"]
 class Telemetry(GortDevice):
     """Telemetry sensors."""
 
-    def __init__(self, gort: GortClient, name: str, actor: str, **kwargs):
+    def __init__(self, gort: Gort, name: str, actor: str, **kwargs):
         super().__init__(gort, name, actor)
 
     async def status(self):

--- a/src/gort/exceptions.py
+++ b/src/gort/exceptions.py
@@ -18,7 +18,7 @@ from gort.enums import ErrorCode
 if TYPE_CHECKING:
     from clu import Command
 
-    from gort.core import RemoteCommand
+    from gort.remote import RemoteCommand
 
 
 def decapitalize_first_letter(s, upper_rest=False):

--- a/src/gort/exposure.py
+++ b/src/gort/exposure.py
@@ -36,7 +36,7 @@ from gort.tools import (
 
 
 if TYPE_CHECKING:
-    from gort.gort import Gort, GortClient
+    from gort.gort import Gort
 
 
 __all__ = ["Exposure", "READOUT_TIME"]
@@ -93,7 +93,7 @@ class Exposure(asyncio.Future["Exposure"]):
 
     def __init__(
         self,
-        gort: Gort | GortClient,
+        gort: Gort,
         exp_no: int | None = None,
         flavour: str | None = "object",
         object: str | None = "",

--- a/src/gort/gort.py
+++ b/src/gort/gort.py
@@ -22,36 +22,38 @@ from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
-    ClassVar,
-    Generic,
     Literal,
-    Sequence,
     Type,
     TypeVar,
 )
 
 from lvmopstools.retrier import Retrier
-from packaging.version import Version
 from rich import pretty, traceback
 from rich.logging import RichHandler
 from typing_extensions import Self
 
-from clu.client import AMQPClient, AMQPReply
+from clu.client import AMQPClient
 from sdsstools.logger import SDSSLogger, get_logger
 from sdsstools.time import get_sjd
 
 from gort import config
-from gort.core import RemoteActor
+from gort.devices.ag import AGSet
+from gort.devices.core import GortDevice, GortDeviceSet
+from gort.devices.enclosure import Enclosure
+from gort.devices.guider import GuiderSet
+from gort.devices.nps import NPSSet
+from gort.devices.spec import SpectrographSet
+from gort.devices.telemetry import TelemetrySet
+from gort.devices.telescope import TelescopeSet
 from gort.enums import Event
 from gort.exceptions import ErrorCode, GortError
 from gort.observer import GortObserver
 from gort.pubsub import notify_event
 from gort.recipes import recipes as recipe_to_class
+from gort.remote import RemoteActor
 from gort.tile import Tile
 from gort.tools import (
     get_temporary_file_path,
-    kubernetes_list_deployments,
     kubernetes_restart_deployment,
     overwatcher_is_running,
     run_in_executor,
@@ -75,7 +77,7 @@ except NameError:
     IPYTHON_DEFAULT_HOOKS = []
 
 
-__all__ = ["GortClient", "Gort", "GortDeviceSet", "GortDevice"]
+__all__ = ["GortClient", "Gort"]
 
 
 DevType = TypeVar("DevType", bound="GortDeviceSet | GortDevice")
@@ -118,14 +120,6 @@ class GortClient(AMQPClient):
         use_rich_output: bool = True,
         log_file_path: str | pathlib.Path | Literal[False] | None = None,
     ):
-        from gort.devices.ag import AGSet
-        from gort.devices.enclosure import Enclosure
-        from gort.devices.guider import GuiderSet
-        from gort.devices.nps import NPSSet
-        from gort.devices.spec import SpectrographSet
-        from gort.devices.telemetry import TelemetrySet as TelemSet
-        from gort.devices.telescope import TelescopeSet as TelSet
-
         self.client_uuid = str(uuid.uuid4()).split("-")[0]
 
         self._console: Console
@@ -147,20 +141,6 @@ class GortClient(AMQPClient):
             password=password,
             log=log,
         )
-
-        self.actors: dict[str, RemoteActor] = {}
-
-        self.config = deepcopy(config)
-
-        self.__device_sets = []
-
-        self.ags = self.add_device(AGSet, self.config["ags"]["devices"])
-        self.guiders = self.add_device(GuiderSet, self.config["guiders"]["devices"])
-        self.telescopes = self.add_device(TelSet, self.config["telescopes"]["devices"])
-        self.nps = self.add_device(NPSSet, self.config["nps"]["devices"])
-        self.specs = self.add_device(SpectrographSet, self.config["specs"]["devices"])
-        self.enclosure = self.add_device(Enclosure, name="enclosure", actor="lvmecp")
-        self.telemetry = self.add_device(TelemSet, self.config["telemetry"]["devices"])
 
     def _prepare_logger(
         self,
@@ -335,62 +315,13 @@ class GortClient(AMQPClient):
         # handler.
         self._setup_async_exception_hooks()
 
-        override_overwatcher = getattr(self, "_override_overwatcher", None)
-        override_envvar = os.environ.get("GORT_OVERRIDE_OVERWATCHER", "0")
-        if override_overwatcher is None:
-            override_overwatcher = False if override_envvar == "0" else True
-
-        if override_overwatcher is None:
-            pass
-        else:
-            overwatcher_running = await overwatcher_is_running(self)
-            if overwatcher_running:
-                if override_overwatcher:
-                    self.log.warning("Overwatcher is running, be careful!")
-                else:
-                    raise GortError(
-                        "Overwatcher is running. If you really want to use GORT "
-                        "initialise it with Gort(override_overwatcher=True).",
-                        error_code=ErrorCode.OVERATCHER_RUNNING,
-                    )
-
-        await asyncio.gather(*[ractor.init() for ractor in self.actors.values()])
-
-        # Initialise device sets.
-        await asyncio.gather(*[dev.init() for dev in self.__device_sets])
-
         return self
-
-    def add_device(self, class_: Type[DevType], *args, **kwargs) -> DevType:
-        """Adds a new device or device set to Gort."""
-
-        ds = class_(self, *args, **kwargs)
-        self.__device_sets.append(ds)
-
-        return ds
 
     @property
     def connected(self):
         """Returns :obj:`True` if the client is connected."""
 
         return self.connection and self.connection.connection is not None
-
-    def add_actor(self, actor: str, device: GortDevice | None = None):
-        """Adds an actor to the programmatic API.
-
-        Parameters
-        ----------
-        actor
-            The name of the actor to add.
-        device
-            A device associated with this actor.
-
-        """
-
-        if actor not in self.actors:
-            self.actors[actor] = RemoteActor(self, actor, device=device)
-
-        return self.actors[actor]
 
     def set_verbosity(self, verbosity: str | int | None = None):
         """Sets the level of verbosity to ``debug``, ``info``, or ``warning``.
@@ -413,283 +344,9 @@ class GortClient(AMQPClient):
         if verbosity not in ["debug", "info", "warning"]:
             raise ValueError("Invalid verbosity value.")
 
-        verbosity_level = logging.getLevelName(verbosity.upper())
-        self.log.sh.setLevel(verbosity_level)
-
-
-GortDeviceType = TypeVar("GortDeviceType", bound="GortDevice")
-
-
-class GortDeviceSet(dict[str, GortDeviceType], Generic[GortDeviceType]):
-    """A set to gort-managed devices.
-
-    Devices can be accessed as items of the :obj:`.GortDeviceSet` dictionary
-    or using dot notation, as attributes.
-
-    Parameters
-    ----------
-    gort
-        The :obj:`.GortClient` instance.
-    data
-        A mapping of device to device info. Each device must at least include
-        an ``actor`` key with the actor to use to communicated with the device.
-        Any other information is passed to the :obj:`.GortDevice` on instantiation.
-    kwargs
-        Other keyword arguments to pass wo the device class.
-
-    """
-
-    __DEVICE_CLASS__: ClassVar[Type["GortDevice"]]
-    __DEPLOYMENTS__: ClassVar[list[str]] = []
-
-    def __init__(self, gort: GortClient, data: dict[str, dict], **kwargs):
-        self.gort = gort
-
-        _dict_data = {}
-        for device_name in data:
-            device_data = data[device_name].copy()
-            actor_name = device_data.pop("actor")
-            _dict_data[device_name] = self.__DEVICE_CLASS__(
-                gort,
-                device_name,
-                actor_name,
-                **device_data,
-                **kwargs,
-            )
-
-        dict.__init__(self, _dict_data)
-
-    async def init(self):
-        """Runs asynchronous tasks that must be executed on init."""
-
-        # Run devices init methods.
-        results = await asyncio.gather(
-            *[dev.init() for dev in self.values()],
-            return_exceptions=True,
-        )
-
-        for idev, result in enumerate(results):
-            if isinstance(result, Exception):
-                self.write_to_log(
-                    f"Failed initialising device {list(self)[idev]} "
-                    f"with error {str(result)}",
-                    "error",
-                )
-
-        return
-
-    def __getattribute__(self, __name: str) -> Any:
-        if __name in self:
-            return self.__getitem__(__name)
-        return super().__getattribute__(__name)
-
-    async def call_device_method(self, method: Callable, *args, **kwargs):
-        """Calls a method in each one of the devices.
-
-        Parameters
-        ----------
-        method
-            The method to call. This must be the abstract class method,
-            not the method from an instantiated object.
-        args,kwargs
-            Arguments to pass to the method.
-
-        """
-
-        if not callable(method):
-            raise GortError("Method is not callable.")
-
-        if hasattr(method, "__self__"):
-            # This is a bound method, so let's get the class method.
-            method = method.__func__
-
-        if not hasattr(self.__DEVICE_CLASS__, method.__name__):
-            raise GortError("Method does not belong to this class devices.")
-
-        devices = self.values()
-
-        return await asyncio.gather(*[method(dev, *args, **kwargs) for dev in devices])
-
-    async def send_command_all(
-        self,
-        command: str,
-        *args,
-        devices: Sequence[str] | None = None,
-        **kwargs,
-    ):
-        """Sends a command to all the devices.
-
-        Parameters
-        ----------
-        command
-            The command to call.
-        args, kwargs
-            Arguments to pass to the :obj:`.RemoteCommand`.
-
-        """
-
-        tasks = []
-        for name, dev in self.items():
-            if devices is not None and name not in devices:
-                continue
-
-            actor_command = dev.actor.commands[command]
-            tasks.append(actor_command(*args, **kwargs))
-
-        return await asyncio.gather(*tasks)
-
-    def write_to_log(
-        self,
-        message: str,
-        level: str = "debug",
-        header: str | None = None,
-    ):
-        """Writes a message to the log with a custom header.
-
-        Parameters
-        ----------
-        message
-            The message to log.
-        level
-            The level to use for logging: ``'debug'``, ``'info'``, ``'warning'``, or
-            ``'error'``.
-        header
-            The header to prepend to the message. By default uses the class name.
-
-        """
-
-        if header is None:
-            header = f"({self.__class__.__name__}) "
-
-        message = f"{header}{message}"
-
-        level = logging.getLevelName(level.upper())
-        assert isinstance(level, int)
-
-        self.gort.log.log(level, message)
-
-    async def restart(self):
-        """Restarts the set deployments and resets all controllers.
-
-        Returns
-        -------
-        result
-            A boolean indicting if the entire restart procedure succeeded.
-
-        """
-
-        failed: bool = False
-
-        self.write_to_log("Restarting Kubernetes deployments.", "info")
-        for deployment in self.__DEPLOYMENTS__:
-            await kubernetes_restart_deployment(deployment)
-
-        self.write_to_log("Waiting 15 seconds for deployments to be ready.", "info")
-        await asyncio.sleep(15)
-
-        # Check that deployments are running.
-        running_deployments = await kubernetes_list_deployments()
-        for deployment in self.__DEPLOYMENTS__:
-            if deployment not in running_deployments:
-                failed = True
-                self.write_to_log(f"Deployment {deployment} did not restart.", "error")
-
-        # Refresh the command models for all the actors.
-        await asyncio.gather(*[actor.refresh() for actor in self.gort.actors.values()])
-
-        # Refresh the device set.
-        await self.init()
-
-        return not failed
-
-
-class GortDevice:
-    """A gort-managed device.
-
-    Parameters
-    ----------
-    gort
-        The :obj:`.GortClient` instance.
-    name
-        The name of the device.
-    actor
-        The name of the actor used to interface with this device. The actor is
-        added to the list of :obj:`.RemoteActor` in the :obj:`.GortClient`.
-
-
-    """
-
-    def __init__(self, gort: GortClient, name: str, actor: str):
-        self.gort = gort
-        self.name = name
-        self.actor = gort.add_actor(actor, device=self)
-
-        # Placeholder version. The real one is retrieved on init.
-        self.version = Version("0.99.0")
-
-    async def init(self):
-        """Runs asynchronous tasks that must be executed on init.
-
-        If the device is part of a :obj:`.DeviceSet`, this method is called
-        by :obj:`.DeviceSet.init`.
-
-        """
-
-        # Get the version of the actor.
-        if "version" in self.actor.commands:
-            try:
-                reply = await self.actor.commands.version()
-                if (version := reply.get("version")) is not None:
-                    self.version = Version(version)
-            except Exception:
-                pass
-
-        return
-
-    def write_to_log(
-        self,
-        message: str,
-        level: str = "debug",
-        header: str | None = None,
-    ):
-        """Writes a message to the log with a custom header.
-
-        Parameters
-        ----------
-        message
-            The message to log.
-        level
-            The level to use for logging: ``'debug'``, ``'info'``, ``'warning'``, or
-            ``'error'``.
-        header
-            The header to prepend to the message. By default uses the device name.
-
-        """
-
-        if header is None:
-            header = f"({self.name}) "
-
-        message = f"{header}{message}"
-
-        level = logging.getLevelName(level.upper())
-        assert isinstance(level, int)
-
-        self.gort.log.log(level, message)
-
-    def log_replies(self, reply: AMQPReply, skip_debug: bool = True):
-        """Outputs command replies."""
-
-        if reply.body:
-            if reply.message_code in ["w"]:
-                level = "warning"
-            elif reply.message_code in ["e", "f", "!"]:
-                level = "error"
-            else:
-                level = "debug"
-                if skip_debug:
-                    return
-
-            self.write_to_log(str(reply.body), level)
+        level_mapping = logging.getLevelNamesMapping()
+        if verbosity_level := level_mapping.get(verbosity.upper()):
+            self.log.sh.setLevel(verbosity_level)
 
 
 class Gort(GortClient):
@@ -725,6 +382,20 @@ class Gort(GortClient):
 
         super().__init__(*args, **kwargs)
 
+        self.actors: dict[str, RemoteActor] = {}
+
+        self.config = deepcopy(config)
+
+        self.__device_sets = []
+
+        self.ags = self.add_device(AGSet, config["ags.devices"])
+        self.guiders = self.add_device(GuiderSet, config["guiders.devices"])
+        self.telescopes = self.add_device(TelescopeSet, config["telescopes.devices"])
+        self.nps = self.add_device(NPSSet, config["nps.devices"])
+        self.specs = self.add_device(SpectrographSet, config["specs.devices"])
+        self.enclosure = self.add_device(Enclosure, name="enclosure", actor="lvmecp")
+        self.telemetry = self.add_device(TelemetrySet, config["telemetry.devices"])
+
         self._override_overwatcher = override_overwatcher
 
         self.observer = GortObserver(self)
@@ -732,6 +403,63 @@ class Gort(GortClient):
 
         if verbosity:
             self.set_verbosity(verbosity)
+
+    async def init(self) -> Self:
+        """Initialises the client and all devices."""
+
+        await super().init()
+
+        override_overwatcher = self._override_overwatcher
+        override_envvar = os.environ.get("GORT_OVERRIDE_OVERWATCHER", "0")
+
+        if override_overwatcher is None:
+            override_overwatcher = False if override_envvar == "0" else True
+
+        if override_overwatcher is None:
+            pass
+        else:
+            overwatcher_running = await overwatcher_is_running(self)
+            if overwatcher_running:
+                if override_overwatcher:
+                    self.log.warning("Overwatcher is running, be careful!")
+                else:
+                    raise GortError(
+                        "Overwatcher is running. If you really want to use GORT "
+                        "initialise it with Gort(override_overwatcher=True).",
+                        error_code=ErrorCode.OVERATCHER_RUNNING,
+                    )
+
+        await asyncio.gather(*[ractor.init() for ractor in self.actors.values()])
+
+        # Initialise device sets.
+        await asyncio.gather(*[dev.init() for dev in self.__device_sets])
+
+        return self
+
+    def add_device(self, class_: Type[DevType], *args, **kwargs) -> DevType:
+        """Adds a new device or device set to Gort."""
+
+        ds = class_(self, *args, **kwargs)
+        self.__device_sets.append(ds)
+
+        return ds
+
+    def add_actor(self, actor: str, device: GortDevice | None = None):
+        """Adds an actor to the programmatic API.
+
+        Parameters
+        ----------
+        actor
+            The name of the actor to add.
+        device
+            A device associated with this actor.
+
+        """
+
+        if actor not in self.actors:
+            self.actors[actor] = RemoteActor(self, actor, device=device)
+
+        return self.actors[actor]
 
     @Retrier(max_attempts=3, delay=3)
     async def emergency_shutdown(self):

--- a/src/gort/gort.py
+++ b/src/gort/gort.py
@@ -37,17 +37,9 @@ from sdsstools.logger import SDSSLogger, get_logger
 from sdsstools.time import get_sjd
 
 from gort import config
-from gort.devices.ag import AGSet
 from gort.devices.core import GortDevice, GortDeviceSet
-from gort.devices.enclosure import Enclosure
-from gort.devices.guider import GuiderSet
-from gort.devices.nps import NPSSet
-from gort.devices.spec import SpectrographSet
-from gort.devices.telemetry import TelemetrySet
-from gort.devices.telescope import TelescopeSet
 from gort.enums import Event
 from gort.exceptions import ErrorCode, GortError
-from gort.observer import GortObserver
 from gort.pubsub import notify_event
 from gort.recipes import recipes as recipe_to_class
 from gort.remote import RemoteActor
@@ -377,6 +369,16 @@ class Gort(GortClient):
         config_file: str | pathlib.Path | None = None,
         **kwargs,
     ):
+        # Not a circular import issue, but here so that importing Gort is a bit faster.
+        from gort.devices.ag import AGSet
+        from gort.devices.enclosure import Enclosure
+        from gort.devices.guider import GuiderSet
+        from gort.devices.nps import NPSSet
+        from gort.devices.spec import SpectrographSet
+        from gort.devices.telemetry import TelemetrySet
+        from gort.devices.telescope import TelescopeSet
+        from gort.observer import GortObserver
+
         if config_file:
             config.load(str(config_file))
 

--- a/src/gort/overwatcher/core.py
+++ b/src/gort/overwatcher/core.py
@@ -14,9 +14,8 @@ from weakref import WeakSet
 
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
-from gort.core import LogNamespace
 from gort.exceptions import GortError
-from gort.tools import cancel_task
+from gort.tools import LogNamespace, cancel_task
 
 
 if TYPE_CHECKING:

--- a/src/gort/overwatcher/helpers/notifier.py
+++ b/src/gort/overwatcher/helpers/notifier.py
@@ -18,7 +18,7 @@ import httpx
 from sdsstools import Configuration
 
 from gort import config
-from gort.core import LogNamespace
+from gort.tools import LogNamespace
 
 
 if TYPE_CHECKING:

--- a/src/gort/overwatcher/overwatcher.py
+++ b/src/gort/overwatcher/overwatcher.py
@@ -19,7 +19,6 @@ from typing import cast
 from sdsstools import Configuration
 from sdsstools.utils import GatheringTaskGroup
 
-from gort.core import LogNamespace
 from gort.exceptions import GortError
 from gort.gort import Gort
 from gort.overwatcher.core import OverwatcherBaseTask, OverwatcherModule
@@ -27,6 +26,7 @@ from gort.overwatcher.helpers import DomeHelper
 from gort.overwatcher.helpers.notifier import NotifierMixIn
 from gort.overwatcher.helpers.tasks import DailyTasks
 from gort.overwatcher.troubleshooter.troubleshooter import Troubleshooter
+from gort.tools import LogNamespace
 
 
 @dataclasses.dataclass

--- a/src/gort/overwatcher/troubleshooter/troubleshooter.py
+++ b/src/gort/overwatcher/troubleshooter/troubleshooter.py
@@ -15,13 +15,13 @@ from time import time
 
 from typing import TYPE_CHECKING, TypedDict
 
-from gort.core import LogNamespace
 from gort.enums import ErrorCode
 from gort.exceptions import (
     GortError,
     TroubleshooterCriticalError,
     TroubleshooterTimeoutError,
 )
+from gort.tools import LogNamespace
 
 from .recipes import TroubleshooterRecipe
 

--- a/src/gort/recipes/calibration.py
+++ b/src/gort/recipes/calibration.py
@@ -33,90 +33,85 @@ class QuickCals(BaseRecipe):
     async def recipe(self):
         """Runs the calibration sequence."""
 
-        from gort import Gort
-
-        gort = self.gort
-        assert isinstance(gort, Gort)
-
         specs_idle = await self.gort.specs.are_idle()
         if not specs_idle:
             raise RuntimeError("Spectrographs are not idle.")
 
-        await gort.cleanup()
+        await self.gort.cleanup()
 
-        gort.log.info("Pointing telescopes to the calibration screen.")
-        await gort.telescopes.goto_named_position("calibration")
+        self.gort.log.info("Pointing telescopes to the calibration screen.")
+        await self.gort.telescopes.goto_named_position("calibration")
 
         ########################
         # Arcs
         ########################
 
-        gort.log.info("Turning on the HgNe lamp.")
-        await gort.nps.calib.on("HgNe")
+        self.gort.log.info("Turning on the HgNe lamp.")
+        await self.gort.nps.calib.on("HgNe")
 
-        gort.log.info("Turning on the Ne lamp.")
-        await gort.nps.calib.on("Neon")
+        self.gort.log.info("Turning on the Ne lamp.")
+        await self.gort.nps.calib.on("Neon")
 
-        gort.log.info("Turning on the Argon lamp.")
-        await gort.nps.calib.on("Argon")
+        self.gort.log.info("Turning on the Argon lamp.")
+        await self.gort.nps.calib.on("Argon")
 
-        gort.log.info("Turning on the Xenon lamp.")
-        await gort.nps.calib.on("Xenon")
+        self.gort.log.info("Turning on the Xenon lamp.")
+        await self.gort.nps.calib.on("Xenon")
 
-        gort.log.info("Waiting 180 seconds for the lamps to warm up.")
+        self.gort.log.info("Waiting 180 seconds for the lamps to warm up.")
         await asyncio.sleep(180)
 
         fiber = random.randint(1, 12)  # select random fibre on std telescope
         fiber_str = f"P1-{fiber}"
-        gort.log.info(f"Taking {fiber_str} exposure.")
-        await gort.telescopes.spec.fibsel.move_to_position(fiber_str)
+        self.gort.log.info(f"Taking {fiber_str} exposure.")
+        await self.gort.telescopes.spec.fibsel.move_to_position(fiber_str)
 
         for exp_time in [10, 50]:
-            await gort.specs.expose(
+            await self.gort.specs.expose(
                 exp_time,
                 flavour="arc",
                 header={"CALIBFIB": f"P1-{fiber}"},
             )
 
-        gort.log.info("Turning off all lamps.")
-        await gort.nps.calib.all_off()
+        self.gort.log.info("Turning off all lamps.")
+        await self.gort.nps.calib.all_off()
 
         ########################
         # Flats
         ########################
 
-        gort.log.info("Turning on the Quartz lamp.")
-        await gort.nps.calib.on("Quartz")
+        self.gort.log.info("Turning on the Quartz lamp.")
+        await self.gort.nps.calib.on("Quartz")
 
-        gort.log.info("Waiting 120 seconds for the lamp to warm up.")
+        self.gort.log.info("Waiting 120 seconds for the lamp to warm up.")
         await asyncio.sleep(120)
 
         exp_quartz = 20
-        await gort.specs.expose(
+        await self.gort.specs.expose(
             exp_quartz,
             flavour="flat",
             header={"CALIBFIB": f"P1-{fiber}"},
         )
 
-        gort.log.info("Turning off the Quartz lamp.")
-        await gort.nps.calib.all_off()
+        self.gort.log.info("Turning off the Quartz lamp.")
+        await self.gort.nps.calib.all_off()
 
-        gort.log.info("Turning on the LDLS lamp.")
-        await gort.nps.calib.on("LDLS")
+        self.gort.log.info("Turning on the LDLS lamp.")
+        await self.gort.nps.calib.on("LDLS")
 
-        gort.log.info("Waiting 300 seconds for the lamp to warm up.")
+        self.gort.log.info("Waiting 300 seconds for the lamp to warm up.")
         await asyncio.sleep(300)
 
         exp_LDLS = 150
 
-        await gort.specs.expose(
+        await self.gort.specs.expose(
             exp_LDLS,
             flavour="flat",
             header={"CALIBFIB": f"P1-{fiber}"},
         )
 
-        gort.log.info("Turning off the LDLS lamp.")
-        await gort.nps.calib.all_off()
+        self.gort.log.info("Turning off the LDLS lamp.")
+        await self.gort.nps.calib.all_off()
 
 
 class BiasSequence(BaseRecipe):
@@ -134,23 +129,18 @@ class BiasSequence(BaseRecipe):
 
         """
 
-        from gort import Gort
-
-        gort = self.gort
-        assert isinstance(gort, Gort)
-
         specs_idle = await self.gort.specs.are_idle()
         if not specs_idle:
             raise RuntimeError("Spectrographs are not idle.")
 
-        gort.log.info("Pointing telescopes to the selfie position.")
-        await gort.telescopes.goto_named_position("selfie")
+        self.gort.log.info("Pointing telescopes to the selfie position.")
+        await self.gort.telescopes.goto_named_position("selfie")
 
-        await gort.nps.calib.all_off()
-        await gort.cleanup()
+        await self.gort.nps.calib.all_off()
+        await self.gort.cleanup()
 
         for _ in range(count):
-            await gort.specs.expose(flavour="bias")
+            await self.gort.specs.expose(flavour="bias")
 
 
 class TwilightFlats(BaseRecipe):
@@ -189,12 +179,7 @@ class TwilightFlats(BaseRecipe):
 
         """
 
-        from gort import Gort
-
-        gort = self.gort
-        assert isinstance(gort, Gort)
-
-        await gort.cleanup()
+        await self.gort.cleanup()
 
         if not (await self.gort.enclosure.is_open()):
             raise RuntimeError("Dome must be open to take twilight flats.")
@@ -219,8 +204,8 @@ class TwilightFlats(BaseRecipe):
             alt = 40.0
             az = 90.0
 
-        gort.log.info("Moving telescopes to point to the twilight sky.")
-        await gort.telescopes.goto_coordinates_all(
+        self.gort.log.info("Moving telescopes to point to the twilight sky.")
+        await self.gort.telescopes.goto_coordinates_all(
             alt=alt,
             az=az,
             altaz_tracking=False,
@@ -277,7 +262,7 @@ class TwilightFlats(BaseRecipe):
             elif is_sunset and all_done and exp_time > self.MAX_EXP_TIME_EXTRA:
                 # We have taken all 12 fibres and some extra ones, but the
                 # exposure time is now too long. Exit.
-                gort.log.debug("Exposure time is too long to take more extra flats.")
+                self.gort.log.debug("Exposure time is too long to take more flats.")
                 break
             elif is_sunset and all_done and exp_time <= self.MAX_EXP_TIME_EXTRA:
                 # Continue taking exposures for extra flats.
@@ -291,20 +276,20 @@ class TwilightFlats(BaseRecipe):
                 exp_time = 1.0
 
             fibre_str = await self.goto_fibre_position(n_fibre, secondary=secondary)
-            gort.log.info(f"Taking {fibre_str} exposure with exp_time={exp_time:.2f}.")
+            self.gort.log.info(f"Exposing {fibre_str} with exp_time={exp_time:.2f}.")
 
             try:
-                await gort.specs.expose(
+                await self.gort.specs.expose(
                     exp_time,
                     flavour="flat",
                     header={"CALIBFIB": fibre_str},
                 )
             except Exception as err:
-                gort.log.error(
+                self.gort.log.error(
                     "Error taking twilight flat exposure. Will ignore since we "
                     f"are on a schedule here. Error is: {err}"
                 )
-                await gort.notify_event(
+                await self.gort.notify_event(
                     Event.ERROR,
                     payload={
                         "error": str(err),
@@ -322,7 +307,7 @@ class TwilightFlats(BaseRecipe):
 
                 # During sunset, after taking all 12 fibres we continue taking
                 # flats until the exposure time reaches MAX_EXP_TIME_EXTRA seconds.
-                gort.log.info(
+                self.gort.log.info(
                     f"All fibres observed. Taking extra flats until the "
                     f"exposure time reaches {self.MAX_EXP_TIME_EXTRA} seconds."
                 )

--- a/src/gort/remote.py
+++ b/src/gort/remote.py
@@ -3,12 +3,11 @@
 #
 # @Author: José Sánchez-Gallego (gallegoj@uw.edu)
 # @Date: 2023-02-07
-# @Filename: core.py
+# @Filename: remote.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
 from __future__ import annotations
 
-import logging
 import warnings
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -30,9 +29,8 @@ if TYPE_CHECKING:
     from clu.client import AMQPReply
     from clu.command import Command
 
-    from gort.gort import GortDevice
-
-    from .gort import GortClient
+    from gort.devices.core import GortDevice
+    from gort.gort import Gort
 
 
 __all__ = ["RemoteActor", "RemoteCommand", "ActorReply"]
@@ -50,7 +48,7 @@ class CommandSet(dict[str, "RemoteCommand"]):
 class RemoteActor:
     """A programmatic representation of a remote actor."""
 
-    def __init__(self, client: GortClient, name: str, device: GortDevice | None = None):
+    def __init__(self, client: Gort, name: str, device: GortDevice | None = None):
         self.client = client
 
         self.name = name
@@ -274,32 +272,3 @@ class ActorReply:
                 return reply[key]
 
         return None
-
-
-class LogNamespace:
-    """A namespace for log messages."""
-
-    def __init__(self, logger: logging.Logger, header: str = "") -> None:
-        self.logger = logger
-        self.header = header
-
-    def debug(self, message: str, *args, **kwargs):
-        self.logger.log(logging.DEBUG, self._get_message(message), *args, **kwargs)
-
-    def info(self, message: str, *args, **kwargs):
-        self.logger.log(logging.INFO, self._get_message(message), *args, **kwargs)
-
-    def warning(self, message: str, *args, **kwargs):
-        self.logger.log(logging.WARNING, self._get_message(message), *args, **kwargs)
-
-    def error(self, message: str, *args, **kwargs):
-        self.logger.log(logging.ERROR, self._get_message(message), *args, **kwargs)
-
-    def critical(self, message: str, *args, **kwargs):
-        self.logger.log(logging.CRITICAL, self._get_message(message), *args, **kwargs)
-
-    def exception(self, *args, **kwargs):
-        self.logger.exception(*args, **kwargs)
-
-    def _get_message(self, message: str):
-        return self.header.format(**locals()) + message

--- a/src/gort/tools.py
+++ b/src/gort/tools.py
@@ -13,6 +13,7 @@ import concurrent.futures
 import datetime
 import functools
 import hashlib
+import logging
 import os
 import pathlib
 import re
@@ -52,7 +53,7 @@ if TYPE_CHECKING:
     from clu import AMQPClient, AMQPReply
 
     from gort.devices.telescope import FibSel
-    from gort.gort import GortClient
+    from gort.gort import Gort
 
 
 __all__ = [
@@ -92,6 +93,7 @@ __all__ = [
     "get_gort_client",
     "add_night_log_comment",
     "async_noop",
+    "LogNamespace",
 ]
 
 AnyPath = str | os.PathLike
@@ -340,7 +342,7 @@ def get_ccd_frame_path(
 
 
 async def move_mask_interval(
-    gort: GortClient,
+    gort: Gort,
     positions: str | list[str] = "P1-*",
     order_by_steps: bool = False,
     total_time: float | None = None,
@@ -737,7 +739,7 @@ async def get_lvmapi_route(route: str, params: dict = {}, **kwargs):
 class GuiderMonitor:
     """A tool to monitor guider outputs and store them in a dataframe."""
 
-    def __init__(self, gort: GortClient, actor: str | None = None):
+    def __init__(self, gort: Gort, actor: str | None = None):
         self.gort = gort
         self.actor = actor
 
@@ -1037,3 +1039,32 @@ async def async_noop(*args, **kwargs):
     """A no-op coroutine."""
 
     return None
+
+
+class LogNamespace:
+    """A namespace for log messages."""
+
+    def __init__(self, logger: logging.Logger, header: str = "") -> None:
+        self.logger = logger
+        self.header = header
+
+    def debug(self, message: str, *args, **kwargs):
+        self.logger.log(logging.DEBUG, self._get_message(message), *args, **kwargs)
+
+    def info(self, message: str, *args, **kwargs):
+        self.logger.log(logging.INFO, self._get_message(message), *args, **kwargs)
+
+    def warning(self, message: str, *args, **kwargs):
+        self.logger.log(logging.WARNING, self._get_message(message), *args, **kwargs)
+
+    def error(self, message: str, *args, **kwargs):
+        self.logger.log(logging.ERROR, self._get_message(message), *args, **kwargs)
+
+    def critical(self, message: str, *args, **kwargs):
+        self.logger.log(logging.CRITICAL, self._get_message(message), *args, **kwargs)
+
+    def exception(self, *args, **kwargs):
+        self.logger.exception(*args, **kwargs)
+
+    def _get_message(self, message: str):
+        return self.header.format(**locals()) + message


### PR DESCRIPTION
A relatively simple refactor of the core classes (`GortClient`, `Gort`, device and remote actor classes) to address #40.

`GortClient` has been removed of anything that is not explicitely related to `AMQPClient` and logging handling. The initialisation of the devices and actors is now part of `Gort`. With this all the devices and other related classes don't need to know about `GortClient` at all and they always receive an instance of `Gort`.

The device core classes have been moved to `devices/core.py`. The remote actor classes have been renamed from `core.py` to `remote.py`.

Fixes #40.