### PR TITLE
Allow to schedule long-term calibrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+### ✨ Improved
+
+* [#49](https://github.com/sdss/lvmgort/pull/49) Add a calibration recipe for long-term calibration and support scheduling them in the Overwatcher.
+
 ### 🏷️ Changed
 
 * Added a fudge factor to the twilight flats exposure time to prevent saturation in the IR band.

--- a/src/gort/etc/actor_schema.json
+++ b/src/gort/etc/actor_schema.json
@@ -37,7 +37,8 @@
           },
           "close_dome_after": {
             "oneOf": [{ "type": "boolean" }, { "type": "null" }]
-          }
+          },
+          "disabled": { "type": "boolean" }
         }
       }
     },

--- a/src/gort/etc/calibrations.yaml
+++ b/src/gort/etc/calibrations.yaml
@@ -48,3 +48,16 @@
 #   close_dome_after: true
 #   abort_observing: true
 #   priority: 10
+
+- name: long_term_calibrations
+  recipe: long_term_calibrations
+  min_start_time: 1800
+  max_start_time: null
+  time_mode: secs_after_sunset
+  after: null
+  required: false
+  dome: closed
+  abort_observing: false
+  priority: 10
+  allow_post_observing_recovery: false
+  disabled: true

--- a/src/gort/etc/lvmgort.yml
+++ b/src/gort/etc/lvmgort.yml
@@ -254,6 +254,11 @@ recipes:
     fudge_factor: 1 # minutes
     max_exp_time: 300 # seconds
     max_exp_time_extra: 100 # seconds
+  long_term_calibrations:
+    n_biases: 7
+    quartz_exp_time: 20
+    ldls_exp_time: 150
+    arc_exp_times: [10, 50]
 
 observer:
   guide_tolerance:

--- a/src/gort/overwatcher/actor/commands.py
+++ b/src/gort/overwatcher/actor/commands.py
@@ -179,6 +179,7 @@ async def list_(command: OverwatcherCommand):
                 "status": cal.state.name.lower(),
                 "requires_dome": cal.model.dome,
                 "close_dome_after": cal.model.close_dome_after,
+                "disabled": cal.model.disabled,
             }
         )
 

--- a/src/gort/overwatcher/actor/commands.py
+++ b/src/gort/overwatcher/actor/commands.py
@@ -212,6 +212,50 @@ async def calibrations_reset(
     return command.finish()
 
 
+@calibrations.command()
+@click.option(
+    "--now",
+    is_flag=True,
+    help="Starts the next calibration immediately.",
+)
+@click.option(
+    "--remove",
+    is_flag=True,
+    help="Removes the scheduled long-term calibrations.",
+)
+async def schedule_long_term_calibrations(
+    command: OverwatcherCommand,
+    now: bool = False,
+    remove: bool = False,
+):
+    """Schedules long-term calibrations."""
+
+    overwatcher = command.actor.overwatcher
+    calibrations = overwatcher.calibrations
+
+    long_term_cals = calibrations.schedule.get_calibration("long_term_calibrations")
+    if long_term_cals is None:
+        return command.fail(error="Long-term calibrations are not defined.")
+
+    if remove:
+        long_term_cals.model.disabled = True
+        return command.finish(text="Long-term calibrations have been unscheduled.")
+
+    # The long term calibrations are disabled by default. Enable them and make sure
+    # that they are taken even if they have failed before or been done already.
+    long_term_cals.model.disabled = False
+    await long_term_cals.record_state(CalibrationState.WAITING)
+
+    if now:
+        command.info("Stopping the current observing loop to allow calibrations.")
+        await overwatcher.observer.stop_observing(
+            immediate=True,
+            reason="Scheduling long-term calibrations",
+        )
+
+    return command.finish(text="Long-term calibrations have been scheduled.")
+
+
 @overwatcher_cli.group()
 def observer(*_):
     """Commands the overwatcher observer."""


### PR DESCRIPTION
Long-term calibrations are now a recipe (`long_term_calibrations`) which can be scheduled via the `lvm.overwatcher calibrations schedule-long-term-calibrations` commands. The latter is mostly intended to be used from LVM Web.