### PR TITLE
Fix emergency shutdown hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#50](https://github.com/sdss/lvmgort/pull/50) Take into account the dither position when calculating `POSCIRA` and `POSCIDE`.
 * [#51](https://github.com/sdss/lvmgort/pull/51) Add an alert when conditions are safe but the Overwatcher has been idle for over 10 minutes.
+* [#52](https://github.com/sdss/lvmgort/pull/52) Fix a bug that prevented an emergency shutdown from completing.
 * Fix logging the configuration in the pre-observing recipe.
 * Disable the current tile when the acquisition fails and the troubleshooter cannot find an issue with the cameras.
 * Prevent recursion error when shutting down due to bad transparency.

--- a/src/gort/overwatcher/actor/commands.py
+++ b/src/gort/overwatcher/actor/commands.py
@@ -92,14 +92,14 @@ async def disable(
             close_dome=close_dome,
             disable_overwatcher=True,
         )
-        return
+        return command.finish(text="Overwatcher has been disabled.")
 
     if overwatcher.state.enabled:
         # This will cancel the observing loop after the current tile.
         overwatcher.state.enabled = False
         await overwatcher.notify("Overwatcher has been disabled.")
 
-    return command.finish()
+    return command.finish(text="Overwatcher has been disabled.")
 
 
 @overwatcher_cli.command()

--- a/src/gort/recipes/operations.py
+++ b/src/gort/recipes/operations.py
@@ -186,9 +186,11 @@ class ShutdownRecipe(BaseRecipe):
             self.gort.log.info("Disabling the overwatcher.")
             tasks.append(self.gort.send_command("lvm.overwatcher", "disable --now"))
 
-        for result in await asyncio.gather(*tasks, return_exceptions=True):
-            if isinstance(result, Exception):
-                self.gort.log.error(f"Error during shutdown: {decap(result)}")
+        for task in tasks:
+            try:
+                await task
+            except Exception as err:
+                self.gort.log.error(f"Error during shutdown: {decap(err)}")
                 errored = True
 
         if park_telescopes:


### PR DESCRIPTION
This was caused bey the `lvm.overwatcher disable --now` command not finishing before returning.